### PR TITLE
Make Dialyzer happy

### DIFF
--- a/include/wsecli.hrl
+++ b/include/wsecli.hrl
@@ -1,1 +1,1 @@
--type socket() :: gen_tcp:socket() | ssl:sslsocket().
+-type socket() :: inet:socket() | ssl:sslsocket().

--- a/src/wsecli.erl
+++ b/src/wsecli.erl
@@ -33,7 +33,7 @@
     on_close   = fun(_Reason) -> undefined end
   }).
 -record(data, {
-    socket                         :: gen_tcp:socket(),
+    socket                         :: inet:socket(),
     handshake                      :: #handshake{},
     cb  = #callbacks{},
     fragmented_message = undefined :: #message{}

--- a/src/wsecli.erl
+++ b/src/wsecli.erl
@@ -34,9 +34,9 @@
   }).
 -record(data, {
     socket                         :: inet:socket(),
-    handshake                      :: #handshake{},
+    handshake                      :: undefined | #handshake{},
     cb  = #callbacks{},
-    fragmented_message = undefined :: #message{}
+    fragmented_message = undefined :: undefined | #message{}
   }).
 
 %%========================================

--- a/src/wsecli.erl
+++ b/src/wsecli.erl
@@ -338,10 +338,11 @@ handle_event({on_close, Callback}, StateName, StateData) ->
 %% @hidden
 -spec handle_sync_event(
   Event     :: stop,
-  From      :: pid(),
+  From      :: {pid(), reference()},
   StateName :: atom(),
   StateData :: #data{}
-  ) -> {stop, stop, term(), #data{}}.
+  ) -> {reply, term(), atom(), term()} |
+       {stop, term(), term(), #data{}}.
 handle_sync_event(stop, _From, closing, StateData) ->
   {reply, {ok, closing}, closing, StateData};
 handle_sync_event(stop, _From, connecting, StateData) ->

--- a/src/wsecli.erl
+++ b/src/wsecli.erl
@@ -46,9 +46,9 @@
 -type client()              :: atom() | pid().
 -type on_open_callback()    :: fun(() -> any()).
 -type on_error_callback()   :: fun((string()) -> any()).
--type data_callback()       :: fun((text, string()) -> any())| fun((binary, binary()) -> any()).
+-type data_callback()       :: fun((text, string()) -> any()) | fun((binary, binary()) -> any()).
 -type on_message_callback() :: data_callback().
--type on_close_callback()   :: data_callback().
+-type on_close_callback()   :: fun((undefined) -> any()).
 
 %%========================================
 %% Constants

--- a/src/wsecli.erl
+++ b/src/wsecli.erl
@@ -258,7 +258,7 @@ on_close(Client, Callback) ->
 -spec init(
   {
     Host     :: string(),
-    Port     :: integer(),
+    Port     :: inet:port_number(),
     Resource :: string(),
     SSL      :: boolean()
   }

--- a/src/wsecli_socket.erl
+++ b/src/wsecli_socket.erl
@@ -25,7 +25,7 @@
 %%========================================
 -spec open(
   Host    :: string(),
-  Port    :: pos_integer(),
+  Port    :: inet:port_number(),
   Type    :: socket_type(),
   Client  :: pid()
   ) ->

--- a/src/wsecli_socket.erl
+++ b/src/wsecli_socket.erl
@@ -37,7 +37,7 @@ open(Host, Port, ssl, Client) ->
   wsecli_socket_ssl:start_link(Host, Port, Client, ?DEFAULT_SOCKET_OPTIONS).
 
 -spec send(
-  Data   :: binary(),
+  Data   :: iolist(),
   Socket :: socket()
   ) -> ok.
 send(Data, Socket) ->

--- a/src/wsecli_socket.erl
+++ b/src/wsecli_socket.erl
@@ -41,13 +41,15 @@ open(Host, Port, ssl, Client) ->
   Socket :: socket()
   ) -> ok.
 send(Data, Socket) ->
-  Socket ! {socket, send, Data}.
+  Socket ! {socket, send, Data},
+  ok.
 
 -spec close(
   Socket :: socket()
   ) -> ok.
 close(Socket) ->
-  Socket ! {socket, close}.
+  Socket ! {socket, close},
+  ok.
 
 %%========================================
 %% Socket API to interact with client

--- a/src/wsecli_socket_plain.erl
+++ b/src/wsecli_socket_plain.erl
@@ -20,10 +20,10 @@
 %%========================================
 -spec start_link(
   Host    :: string(),
-  Port    :: pos_integer(),
+  Port    :: inet:port_number(),
   Client  :: pid(),
-  Options :: list({atom(), term()})
-) -> {ok, socket()}.
+  Options :: list(gen_tcp:connect_option())
+) -> {ok, socket()} | {error, term()}.
 start_link(Host, Port, Client, Options) ->
   proc_lib:start_link(?MODULE, init, [Host, Port, Client, Options]).
 
@@ -31,7 +31,7 @@ start_link(Host, Port, Client, Options) ->
   Host    :: string(),
   Port    :: pos_integer(),
   Client  :: pid(),
-  Options :: list({atom(), term()})
+  Options :: list(gen_tcp:connect_option())
   ) -> ok.
 init(Host, Port, Client, Options) ->
   {ok, Socket} = gen_tcp:connect(Host, Port, Options),

--- a/src/wsecli_socket_plain.erl
+++ b/src/wsecli_socket_plain.erl
@@ -29,7 +29,7 @@ start_link(Host, Port, Client, Options) ->
 
 -spec init(
   Host    :: string(),
-  Port    :: pos_integer(),
+  Port    :: inet:port_number(),
   Client  :: pid(),
   Options :: list(gen_tcp:connect_option())
   ) -> ok.

--- a/src/wsecli_socket_ssl.erl
+++ b/src/wsecli_socket_ssl.erl
@@ -29,7 +29,7 @@ start_link(Host, Port, Client, Options) ->
 
 -spec init(
   Host    :: string(),
-  Port    :: pos_integer(),
+  Port    :: inet:port_number(),
   Client  :: pid(),
   Options :: list(ssl:connect_option())
   ) -> ok.

--- a/src/wsecli_socket_ssl.erl
+++ b/src/wsecli_socket_ssl.erl
@@ -20,9 +20,9 @@
 %%========================================
 -spec start_link(
   Host    :: string(),
-  Port    :: pos_integer(),
+  Port    :: inet:port_number(),
   Client  :: pid(),
-  Options :: list({atom(), term()})
+  Options :: list(ssl:connect_option())
 ) -> {ok, socket()}.
 start_link(Host, Port, Client, Options) ->
   proc_lib:start_link(?MODULE, init, [Host, Port, Client, Options]).
@@ -31,7 +31,7 @@ start_link(Host, Port, Client, Options) ->
   Host    :: string(),
   Port    :: pos_integer(),
   Client  :: pid(),
-  Options :: list({atom(), term()})
+  Options :: list(ssl:connect_option())
   ) -> ok.
 init(Host, Port, Client, Options) ->
   {ok, Socket} = ssl:connect(Host, Port, Options),


### PR DESCRIPTION
These changes lead to no errors/warning in Dialyzer output except some related to unused functions in `mock_http_server`. I guess these functions might be used someday, so didn't remove them.

Especially https://github.com/lavrin/wsecli/commit/b4603f5f74d44c48726dc875bc7b1019fda2c102 is important, because it (temporarily, I guess) fixes the problem I reported in https://github.com/madtrick/wsecli/issues/15.

My master branch contains a Makefile with Dialyzer setup I used.
